### PR TITLE
Fix assigment in aggregator

### DIFF
--- a/documentation/source/tutorial_data.rst
+++ b/documentation/source/tutorial_data.rst
@@ -115,7 +115,7 @@ Calculating mean and standard deviation in 10 frame window, with 1 frame hop::
         win_length_frames=10,
         hop_length_frames=1,
     )
-    data_aggregator.aggregate(data)
+    data = data_aggregator.aggregate(data)
     print(data.shape)
     # (80, 501)
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
```
data = dcase_util.utils.Example.feature_container()
print(data.shape)

data_aggregator = dcase_util.data.Aggregator(
    recipe=['mean', 'std'],
    win_length_frames=10,
    hop_length_frames=1,
)

data_aggregator.aggregate(data)
print(data.shape)
```
produces:
```
(40, 501)
(40, 501)
```
Fix assignment to:
```
data = data_aggregator.aggregate(data)
```
to obtain desired effect
```
(40, 501)
(80, 501)
```

